### PR TITLE
Fix for quote signs encoded in the value of the JSON field

### DIFF
--- a/NASA_APOD/NASA_APOD/APOD.cs
+++ b/NASA_APOD/NASA_APOD/APOD.cs
@@ -97,9 +97,15 @@ namespace NASA_APOD
             {
                 int keyStartPos = json.IndexOf(_key);
                 int valueStartPos = keyStartPos + _key.Length + 2; //2 - quote and comma?
-                int valueLength = json.IndexOf('"', valueStartPos);
-                    //valueLength = json.LastIndexOf()
-                String outstr = json.Substring(valueStartPos, valueLength - valueStartPos);
+                
+                // look for end of value (quote and comma) 
+                // or end of value and end of JSON (quote and closing bracket)
+                int valueLength = json.IndexOf("\",", valueStartPos);
+                if (valueLength == -1)
+                    valueLength = json.IndexOf("\"}", valueStartPos);
+                
+                // replace any \" which may occure inside of value with single quote
+                String outstr = json.Substring(valueStartPos, valueLength - valueStartPos).Replace("\\\"", "\"");
                 return outstr;
             }
             else return null;


### PR DESCRIPTION
I stumpled upon this repository by accident and seen the issue - this fix is looking for `",` or "`}` as ending of value of JSON field, thus ignoring `\"` which may be inside the value itself. Tested on 2019-09-09 where there is a few quote sign in the explanation field.

Closes #1.

(also you can remove Newtonsoft.Json from your package.config as you switched to your own JSON parsing)